### PR TITLE
Use [first,last]ElementChild over [first,last]Child

### DIFF
--- a/src/lib/infiniteScroll/index.ts
+++ b/src/lib/infiniteScroll/index.ts
@@ -4,12 +4,12 @@ type loadFnType = () => void;
 
 export function infiniteScroll(node: HTMLElement, loadFn: loadFnType) {
 
-  let offsetHeight = (node.firstChild?.offsetHeight) / 2;
+  let offsetHeight = (node.firstElementChild?.offsetHeight) / 2;
   let nodeRect = node.getBoundingClientRect();
   let nodeTop = nodeRect.top + offsetHeight;
 
   const watchScrolling = () => {
-    let lastChild = node.lastChild;
+    let lastChild = node.lastElementChild;
     let rect = lastChild?.getBoundingClientRect();
     if ((rect.bottom - nodeTop) <= (node.offsetHeight)) {
       loadFn();


### PR DESCRIPTION
Resolves a bug where non-element children can cause the infiniteScroll calculates to be incorrect

Closes #2 